### PR TITLE
Add SignUpButton to popup

### DIFF
--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,6 +1,7 @@
 import {
   ClerkProvider,
   SignInButton,
+  SignUpButton,
   SignedIn,
   SignedOut,
   UserButton
@@ -28,6 +29,7 @@ function IndexPopup() {
         <header className="plasmo-w-full">
           <SignedOut>
             <SignInButton mode="modal" />
+            <SignUpButton mode="modal" />
           </SignedOut>
           <SignedIn>
             <UserButton />


### PR DESCRIPTION
## Summary
- Adds `SignUpButton` import and renders it alongside `SignInButton` in the popup

These changes bring alignment with the upcoming updated docs/guides -> https://github.com/clerk/clerk-docs/pull/3146

## Test plan
- [ ] Load the extension and verify both Sign In and Sign Up buttons appear when signed out
- [ ] Verify both buttons open their respective modals

🤖 Generated with [Claude Code](https://claude.com/claude-code)